### PR TITLE
Fix CAN2 filters and remove the `Slave` associate type

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -209,7 +209,7 @@ impl<I: MasterInstance> MasterFilters<'_, I> {
     }
 
     /// Accesses the filters assigned to the slave peripheral.
-    pub fn slave_filters(&mut self) -> SlaveFilters<'_, I::Slave> {
+    pub fn slave_filters(&mut self) -> SlaveFilters<'_, I> {
         // NB: This mutably borrows `self`, so it has full access to the filter bank registers.
         SlaveFilters {
             start_idx: self.bank_count,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,11 +79,8 @@ pub unsafe trait FilterOwner: Instance {
 ///
 /// # Safety
 ///
-/// This trait must only be implemented when `Self::Slave` is actually the associated slave instance
-/// of `Self`.
-pub unsafe trait MasterInstance: FilterOwner {
-    type Slave: Instance;
-}
+/// This trait must only be implemented when there is actually an associated slave instance.
+pub unsafe trait MasterInstance: FilterOwner {}
 
 // TODO: what to do with these?
 /*

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -26,9 +26,7 @@ unsafe impl Instance for CAN1 {
     const REGISTERS: *mut bxcan::RegisterBlock = 0x4000_6400 as *mut _;
 }
 
-/*unsafe impl MasterInstance for CAN1 {
-    type Slave = CAN2;
-}*/
+// unsafe impl MasterInstance for CAN1 {}
 
 unsafe impl FilterOwner for CAN1 {
     /// F103 is a medium-density device, which have 14 total filter banks.


### PR DESCRIPTION
CAN2 (slave) needs to use CAN1 (master) register block for its filte configuration